### PR TITLE
describe pod $PODNAME does not work

### DIFF
--- a/documentation/modules/ROOT/pages/resources.adoc
+++ b/documentation/modules/ROOT/pages/resources.adoc
@@ -22,7 +22,7 @@ kubectl apply -f apps/kubefiles/myboot-deployment.yml
 Describe the pod
 ----
 PODNAME=$(kubectl get pod  -l app=myboot -o name)
-kubectl describe pod $PODNAME
+kubectl describe $PODNAME
 ----
 
 There are not resource limits configured for the pod.


### PR DESCRIPTION
it is  kubectl describe $PODNAME

because $PODNAME from this example maps to pod/myboot-66d7d57687-qwnnf

issue #2 